### PR TITLE
chapter 12 - PASSWORD RESET

### DIFF
--- a/sample_app/app/controllers/password_resets_controller.rb
+++ b/sample_app/app/controllers/password_resets_controller.rb
@@ -1,0 +1,59 @@
+class PasswordResetsController < ApplicationController
+  before_action :get_user, :valid_user, :check_expiration, only: %i(edit update)
+
+  def new; end
+
+  def create
+    @user = User.find_by email: params[:password_reset][:email].downcase
+    if @user
+      @user.create_reset_digest
+      @user.send_password_reset_email
+      flash[:info] = t "mails.email_sent"
+      redirect_to root_url
+    else
+      flash.now[:danger] = t "mails.send_fail"
+      render :new
+    end
+  end
+
+  def edit; end
+
+  def update
+    if params[:user][:password].blank?
+      @user.errors.add :password, t("shared.cant_be_empty")
+      render :edit
+    elsif @user.update user_params
+      log_in @user
+      @user.update reset_digest: nil
+      flash[:success] = t "shared.password_has_been_reset"
+      redirect_to @user
+    else
+      flash[:danger] = t "shared.can_not_reset_password"
+      render :edit
+    end
+  end
+
+  private
+
+  def user_params
+    params.require :user.permit PASSWORD_PARAMS
+  end
+
+
+  def get_user
+    @user = User.find_by email: params[:email]
+    return if @user
+    flash[:danger] = t "shared.user_not_found"
+    redirect_to root_url
+  end
+
+  def valid_user
+    redirect_to root_url unless @user&.activated? && @user&.authenticated?(:reset, params[:id])
+  end
+
+  def check_expiration
+    return unless @user.password_reset_expired?
+    flash[:danger] = t "shared.password_reset_has_expired"
+    redirect_to new_password_reset_url
+  end
+end

--- a/sample_app/app/mailers/user_mailer.rb
+++ b/sample_app/app/mailers/user_mailer.rb
@@ -3,4 +3,9 @@ class UserMailer < ApplicationMailer
     @user = user
     mail to: user.email, subject: t("shared.account_activation")
   end
+
+  def password_reset user
+    @user = user
+    mail to: user.email, subject: t("shared.password_reset")
+  end
 end

--- a/sample_app/app/models/user.rb
+++ b/sample_app/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   VALID_EMAIL_REGEX = Settings.user.email.email_regex
   USERS_PARAMS = %i(name email password password_confirmation).freeze
 
-  attr_accessor :remember_token, :activation_token
+  attr_accessor :remember_token, :activation_token, :reset_token
 
   before_create :create_activation_digest
   before_save :downcase_email
@@ -52,6 +52,19 @@ class User < ApplicationRecord
 
   def send_activation_email
     UserMailer.account_activation(self).deliver_now
+  end
+
+  def create_reset_digest
+    self.reset_token = User.new_token
+    update reset_digest: User.digest(reset_token), reset_sent_at: Time.zone.now
+  end
+
+  def send_password_reset_email
+    UserMailer.password_reset(self).deliver_now
+  end
+
+  def password_reset_expired?
+    reset_sent_at < Settings.user.password_reset_expired.hours.ago
   end
 
   def forget

--- a/sample_app/app/views/password_resets/edit.html.erb
+++ b/sample_app/app/views/password_resets/edit.html.erb
@@ -1,0 +1,15 @@
+<% provide :title, t("password_reset.title") %>
+<h1><%= t "password_reset.title" %></h1>
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_for @user, url: password_reset_path(params[:id]) do |f| %>
+    <%= render "layouts/errors" %>
+      <%= hidden_field_tag :email, @user.email %>
+      <%= f.label t("password_reset.password") %>
+      <%= f.password_field :password, class: "form-control" %>
+      <%= f.label :password_confirmation, t("password_reset.confirmation") %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+      <%= f.submit t("password_reset.update_password"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/sample_app/app/views/password_resets/new.html.erb
+++ b/sample_app/app/views/password_resets/new.html.erb
@@ -1,0 +1,11 @@
+<% provide :title, t("btn.forgot_password") %>
+<h1><%= t "btn.forgot_password" %></h1>
+<div class="row">
+  <div class="mx-auto col-md-6 col-md-offset-3">
+    <%= form_with scope: :password_reset, url: password_resets_path, local: true do |f| %>
+      <%= f.label :email %>
+      <%= f.email_field :email, class: "form-control" %>
+      <%= f.submit t("btn.submit"), class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/sample_app/app/views/sessions/new.html.erb
+++ b/sample_app/app/views/sessions/new.html.erb
@@ -7,6 +7,7 @@
       <%= f.email_field :email, class: "form-control" %>
 
       <%= f.label :password, t(".password") %>
+      <%= link_to t("user.forgot_password"), new_password_reset_path %>
       <%= f.password_field :password, class: "form-control" %>
 
       <%= f.label :remember_me, class: "checkbox inline" do %>

--- a/sample_app/app/views/static_pages/home.html.erb
+++ b/sample_app/app/views/static_pages/home.html.erb
@@ -5,4 +5,4 @@
   <%= link_to t(".home_content1"), Settings.home_page %>
   <%= t ".home_content2" %>
 </p>
-<%= link_to t(".sign_up_now!"), '#', class: "btn btn-lg btn-primary" %>
+<%= link_to t(".sign_up_now!"), signup_path, class: "btn btn-lg btn-primary" %>

--- a/sample_app/config/locales/en.yml
+++ b/sample_app/config/locales/en.yml
@@ -88,7 +88,8 @@ en:
     account: "Account"
     users: "Users"
     remember: "Remember me on this computer"
-
+    submit: "Submit"
+    forgot_password: "Forgot Password"
   edit:
     title: "Edit user"
     update: "Update your profile"
@@ -108,3 +109,11 @@ en:
     welcome: "Welcome to the Sample App! Click on the link below to activate your account: "
     activate: "Activate"
     please_activate: "Please check your email to activate your account."
+    email_send: "Email sent with password reset instructions"
+    send_fail: "Email address not found"
+  password_reset:
+    title: "Reset passoword"
+    email: "Email"
+    password: "Password"
+    confirmation: "Confirmation"
+    update_password: "Update password"

--- a/sample_app/config/locales/vi.yml
+++ b/sample_app/config/locales/vi.yml
@@ -88,6 +88,8 @@ vi:
     account: "Tài khoản"
     users: "Người dùng"
     remember: "Nhớ tôi ở trên máy tính này"
+    submit: "Submit"
+    forgot_password: "Quên mật khẩu"
   edit:
     title: "Chỉnh sửa thông tin"
     update: "Cập nhật hồ sơ của bạn"
@@ -107,3 +109,11 @@ vi:
     welcome: "Chào mừng bạn đến với ứng dụng mẫu, hãy kích hoạt tài khoản bằng đường dẫn sau: "
     activate: "Kích hoạt"
     please_activate: "Kiểm tra email để kích hoạt tài khoản của bạn."
+    email_send: "Đã gửi email thay đổi mật khẩu"
+    send_fail: "Không tìm thấy địa chỉ email"
+  password_reset:
+    title: "Đặt lại mật khẩu"
+    email: "Email"
+    password: "Mật khẩu"
+    confirmation: "Nhập lại mật khẩu"
+    update_password: "Cập nhật mật khẩu"

--- a/sample_app/config/routes.rb
+++ b/sample_app/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
     get "/login", to: "sessions#new"
     post "/login", to: "sessions#create"
     delete "/logout", to: "sessions#destroy"
+    get "password_resets/new"
+    get "password_resets/edit"
     resources :users
     resources :account_activations, only: [:edit]
+    resources :password_resets, except: %i(index show destroy)
   end
 end

--- a/sample_app/config/settings.yml
+++ b/sample_app/config/settings.yml
@@ -15,4 +15,5 @@ user:
   checkbox_value: "1"
   ava_size: 80
   ava_small_size: 50
+  password_reset_expired: 2
 pagination: 10

--- a/sample_app/db/migrate/20200810015057_add_reset_to_users.rb
+++ b/sample_app/db/migrate/20200810015057_add_reset_to_users.rb
@@ -1,0 +1,6 @@
+class AddResetToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :reset_digest, :string
+    add_column :users, :reset_sent_at, :datetime
+  end
+end

--- a/sample_app/db/schema.rb
+++ b/sample_app/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_07_020411) do
+ActiveRecord::Schema.define(version: 2020_08_10_015057) do
 
   create_table "users", force: :cascade do |t|
     t.string "name"
@@ -23,6 +23,8 @@ ActiveRecord::Schema.define(version: 2020_08_07_020411) do
     t.string "activation_digest"
     t.boolean "activated", default: false
     t.datetime "activated_at"
+    t.string "reset_digest"
+    t.datetime "reset_sent_at"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 


### PR DESCRIPTION


Cho phép người dùng đặt lại mật khẩu nếu trong TH quên mất.
Quy trình chung:

    Người dùng nhập email để đặt lại mật khẩu.
    Kiểm tra tính hợp lệ email
    Sinh ra reset_token và phiên bản mã hóa của nó.
    Lưu phiên bản mã hóa vào db. Tạo link reset với reset_token cùng email rồi gửi thông qua email cho người dùng.
    Người dùng click link. Kiểm tra hợp lệ sẽ render ra form thay đổi mật khẩu.

